### PR TITLE
Add support for fallback proxy

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true,
+    "quoteProps": "consistent"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/ColumnsView.js
+++ b/src/ColumnsView.js
@@ -1,32 +1,33 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ResourcesColumn from './ResourcesColumn';
+import appConfig from './config';
 import async from 'async';
-import { Breadcrumb } from 'carbon-components-react'
+import { Breadcrumb } from 'carbon-components-react';
 
 /*
  * A ColumnsView renders a list of ResourcesColumns, each of which renders a list
  * of ResourceItems. Columns and added and removed from the right-most column based on
  * the OSLC resource and link type property selected.
- * 
+ *
  * The state of this ColumnsView is an array of an array of OSLC Compact resources, each of which
  * is displayed in a separate column.
  */
 class ColumnsView extends Component {
   static propTypes = {
-    root: PropTypes.object,   // the root OSLC Compact resource representation
-    server: PropTypes.object  // An OSLCServer to use to access resources
-  }
+    root: PropTypes.object, // the root OSLC Compact resource representation
+    server: PropTypes.object, // An OSLCServer to use to access resources
+  };
 
   static defaultProps = {
     root: [[null]],
-    server: null
-  }
+    server: null,
+  };
 
   constructor(props) {
     super(props);
     // State is an array of an array of Compact resource representations, one for each column
-    this.state = {data: [[null]]};
+    this.state = { data: [[null]] };
 
     this.handleLinkTypeSelected = this.handleLinkTypeSelected.bind(this);
     this.handleResourceSelected = this.handleResourceSelected.bind(this);
@@ -46,31 +47,69 @@ class ColumnsView extends Component {
     let options = {
       uri: null,
       headers: {
-      'Accept': 'application/x-oslc-compact+xml;q=0.5,application/rdf+xml;q=0.4',
-      'OSLC-Core-Version': '2.0'}
+        'Accept':
+          'application/x-oslc-compact+xml;q=0.5,application/rdf+xml;q=0.4',
+        'OSLC-Core-Version': '2.0',
+      },
     };
 
-    async.forEach(objectURIs, (objectURI, callback) => {
-      options.uri = objectURI;
-      server.read(options, (err, resource) => {
-        if (!err) {
-          previews.push(resource);
-          return callback();          
-        } else {
-          console.log(`Could not read resource ${objectURI}, status: ${err}`);
-          return callback()
-        }
-      });
-    }, err => {
-      let data = this.state.data.slice(0, columnIndex+1);
-      data.push(previews);
-      this.setState({data: data}); 
-    });
+    async.forEach(
+      objectURIs,
+      (objectURI, callback) => {
+        //todo refactor into a sinle client class
+        options.uri = objectURI;
+        // todo implement a cachingProxy
+        server.read(options, (err, resource) => {
+          if (!err) {
+            previews.push(resource);
+            return callback();
+          } else {
+            //todo make configurable
+            if (appConfig.fallbackProxy) {
+              let uriHasComponents = objectURI.indexOf('?');
+              var proxyUri = null;
+              if (uriHasComponents > -1) {
+                let uriBase = objectURI.slice(0, uriHasComponents);
+                let uriComponents = objectURI.slice(uriHasComponents);
+                proxyUri =
+                  encodeURI(uriBase) + encodeURIComponent(uriComponents);
+              } else {
+                proxyUri = encodeURI(objectURI);
+              }
+
+              options.uri = appConfig.fallbackProxy + proxyUri;
+              server.read(options, (err, resource) => {
+                if (!err) {
+                  resource.id.value = objectURI; // restore the URI
+                  previews.push(resource);
+                  return callback();
+                } else {
+                  console.log(
+                    `Could not read resource ${objectURI}, status: ${err}`
+                  );
+                  return callback();
+                }
+              });
+            } else {
+              console.log(
+                `Could not read resource ${objectURI}, status: ${err}`
+              );
+              return callback();
+            }
+          }
+        });
+      },
+      (err) => {
+        let data = this.state.data.slice(0, columnIndex + 1);
+        data.push(previews);
+        this.setState({ data: data });
+      }
+    );
   }
 
   handleResourceSelected(rowIndex, columnIndex) {
-    let data = this.state.data.slice(0, columnIndex+1);
-    this.setState({data: data});
+    let data = this.state.data.slice(0, columnIndex + 1);
+    this.setState({ data: data });
   }
 
   render() {
@@ -80,27 +119,26 @@ class ColumnsView extends Component {
 
     // did the root change? If so, start over with a new first left column
     if (root && root !== this.state.data[0][0]) {
-      this.setState({data: [[root]]}); // one column with one resource
+      this.setState({ data: [[root]] }); // one column with one resource
       return null;
     }
 
     if (!this.state.data[0][0]) return null; // no data yet
-    
+
     let columns = this.state.data.map((resources, index) => {
-       return (<ResourcesColumn 
-        resources={resources} 
-        columnIndex={index} key={index} 
-        server={server} 
-        onResourceSelected={self.handleResourceSelected}
-        onLinkTypeSelected={self.handleLinkTypeSelected} 
-      />)
+      return (
+        <ResourcesColumn
+          resources={resources}
+          columnIndex={index}
+          key={index}
+          server={server}
+          onResourceSelected={self.handleResourceSelected}
+          onLinkTypeSelected={self.handleLinkTypeSelected}
+        />
+      );
     });
-    
-    return (
-      <div className='columns-view'>
-        {columns}
-      </div>      
-    )
+
+    return <div className="columns-view">{columns}</div>;
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,7 @@
+let appConfig = {
+  cachingProxy: false,
+  fallbackProxy: false,
+  // fallbackProxy: 'http://localhost:8080/r/',
+};
+
+export default appConfig;


### PR DESCRIPTION
After thinking about https://github.com/oslc-op/oslc-specs/issues/458, I tried to get OSLC Browser to work **without** ignoring CORS. I had to do a few tricky steps but still did not manage to do it because there is limit to how many servers I can update.

First, I had to add CORS filters to https://github.com/oslc-op/refimpl/commit/66527f65a3f16e7785a303ecb1bf4d179d6d9feb. Now, this is not possible to do on an app you don't have code access to but I have some Nginx and Apache HTTPD snippets to duct tape it.

Next, I hit the problem of OSLC CM vocab lacking CORS headers and, finally, I think I would have hit it with DCTerms. I still think it's a critical issue to address. I will keep suggesting OSLC to specify it properly and I am planning to suggest https://archivo.dbpedia.org/ to add ontology "fetchability" in a browser as a 5th star.

Now, I realised that for OSLC Browser to work, we absolutely need a proxy. As opposed to Jazz approach, I am suggesting to:

- use a proxy only as a fallback
- use it only for public read-only resource and demand proper CORS for authenticated and read/write resources.

This PR adds support for a configurable fallback proxy.

OSLC CORS will be fixed in https://github.com/oslc-op/website-content-negotiation/issues/8
 